### PR TITLE
[jshell] exercise 4 fix typo and type

### DIFF
--- a/src/main/java/jug/lodz/workshop/jshellworkshop/exercises/exercise4.jsh
+++ b/src/main/java/jug/lodz/workshop/jshellworkshop/exercises/exercise4.jsh
@@ -26,8 +26,8 @@ List<User> us=List.of(u1,u2,u3,u4)
 //implement method sortUsers(us) which returns list of alphabetically sorted users
 //remember that comparator is just a two arguments function
 void checkExercise4(){
-    String[] expected=sortUsers(us).stream().map(u->u.name).toArray();
-    prn.accept("sortUsers() : "+Arrays.equals(excpected,
+    String[] expected = sortUsers(us).stream().map(u -> u.name).toArray(String[]::new);
+    prn.accept("sortUsers() : "+Arrays.equals(expected,
     new String[]{ "Agnieszka", "BożeBożeBożenka", "Roman", "Zdzislaw"}
     ));
 }


### PR DESCRIPTION
fix
```
|  Error:
|  incompatible types: java.lang.Object[] cannot be converted to java.lang.String[]
|      String[] expected = sortUsers(us).stream().map(u -> u.name).toArray();
|                          ^-----------------------------------------------^
```
and
```
|  created method checkExercise4(), however, it cannot be invoked until variable excpected is declared
```